### PR TITLE
Removed name of non-existent script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
             '{0}_version_report = {0}:report_binaries'.format(__pkg_name__, )
         ]
     },
-    scripts=['scripts/medaka_consensus', 'scripts/medaka_variant', 'scripts/mini_align'],
+    scripts=['scripts/medaka_consensus', 'scripts/medaka_variant'],
     zip_safe=False,
     cmdclass={
         'build_ext': HTSBuild


### PR DESCRIPTION
Script mini-align does not appear to exists in scripts directory.