### PR TITLE
Modifying the samtools index call

### DIFF
--- a/scripts/medaka_variant
+++ b/scripts/medaka_variant
@@ -273,7 +273,7 @@ run_samtools_index () {
 
     if [[ ! -e ${INDEX} ]]; then
         echo "Running samtools index on ${BAM}."
-        samtools index ${BAM} -@ ${THREADS} \
+        samtools index -@ ${THREADS} ${BAM}  \
             || (echo "Failed to index bam ${BAM}." && exit 1)
         echo "Bam index in ${OUTPUT}/${INDEX}."
     else


### PR DESCRIPTION
 It was breaking due to the -@ b…eing interpreted as optional output file. Moving this before the BAM argument fixes the issue. 