### PR TITLE
Hotfix/smolecule error message

### DIFF
--- a/medaka/smolecule.py
+++ b/medaka/smolecule.py
@@ -231,7 +231,7 @@ class Read(object):
                     stderr=subprocess.PIPE
                 )
             except subprocess.CalledProcessError as e:
-                print("\n".join("RACON FAILED", e.cmd, e.stdout, e.stderr))
+                print("\n".join(("RACON FAILED", e.cmd, e.stdout, e.stderr)))
             racon_seq = out.decode().splitlines()[1]
         return racon_seq
 

--- a/medaka/smolecule.py
+++ b/medaka/smolecule.py
@@ -230,9 +230,13 @@ class Read(object):
                     ['racon', fasta, overlaps, ref_fasta] + opts,
                     stderr=subprocess.PIPE
                 )
+                racon_seq = out.decode().splitlines()[1]
             except subprocess.CalledProcessError as e:
-                print("\n".join(("RACON FAILED", e.cmd, e.stdout, e.stderr)))
-            racon_seq = out.decode().splitlines()[1]
+                print("RACON FAILED\nRACON COMMAND IS:")
+                print(' '.join(str(v) for v in e.cmd))
+                print(e.stderr.decode('UTF-8'))
+                print(e.stdout.decode('UTF-8'))
+                racon_seq = self.consensus
         return racon_seq
 
     def orient_subreads(self):


### PR DESCRIPTION
This commit fixes these two errors that arise from the original code:

1. join() takes exactly one argument (4 given)
2. local variable 'out' referenced before assignment