### PR TITLE
Minor fixes

### DIFF
--- a/medaka/common.py
+++ b/medaka/common.py
@@ -596,7 +596,7 @@ def mkdir_p(path, info=None):
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             if info is not None:
                 info = " {}".format(info)
-            logging.warn("The path {} exists.{}".format(path, info))
+            logging.warning("The path {} exists.{}".format(path, info))
             pass
         else:
             raise

--- a/medaka/common.py
+++ b/medaka/common.py
@@ -612,7 +612,7 @@ def grouper(gen, batch_size=4):
             except StopIteration:
                 if len(batch) > 0:
                     yield batch
-                raise StopIteration
+                return
         yield batch
 
 

--- a/medaka/features.py
+++ b/medaka/features.py
@@ -778,7 +778,7 @@ def create_samples(args):
     reg_str = '\n'.join(['\t\t\t{}'.format(r) for r in regions])
     logger.info('Got regions:\n{}'.format(reg_str))
     if args.truth is None:
-        logger.warn(
+        logger.warning(
             'Running medaka features without a truth bam, '
             'unlabelled data will be produced. Is this intended?')
         time.sleep(3)


### PR DESCRIPTION
* Migrate away from deprecated methods
  See: https://stackoverflow.com/a/15655674
* Fix StopIteration exception usage
  Since python >= 3.7, StopIteration error raised in a generator is transformed into a RuntimeError automatically and causes tests to fail. This patch fixes it and should be compatible with python 3.5.
  https://www.python.org/dev/peps/pep-0479/
