### PR TITLE
Tensorflow 2.x patch 1

### DIFF
--- a/medaka/models.py
+++ b/medaka/models.py
@@ -133,7 +133,7 @@ def build_model(feature_len, num_classes, gru_size=128,
 
     #  Tensorflow2 uses a fast cuDNN implementation if a GPU is available
     #  and the arguments to the layer meet the CuDNN kernal requirements
-    if tf.config.list_physical_devices('GPU'):
+    if len(tf.test.gpu_device_name()) > 0:
         logger.info("GPU available: building model with cudnn optimization")
 
     model = Sequential()

--- a/medaka/prediction.py
+++ b/medaka/prediction.py
@@ -94,7 +94,7 @@ def predict(args):
     if args.threads > 2:
         logger.warning("Reducing threads to 2, anymore is a waste.")
         args.threads = 2
-        if len(tf.config.list_physical_devices('GPU')) == 0:
+        if len(tf.test.gpu_device_name()) == 0:
             logger.info(
                 "It looks like you are running medaka without a GPU "
                 "and attempted to set a high number of threads. We "
@@ -126,7 +126,7 @@ def predict(args):
         feature_encoder.tag_keep_missing = args.tag_keep_missing
         feature_encoder.read_group = args.RG
 
-        if len(tf.config.list_physical_devices('GPU')) > 0:
+        if len(tf.test.gpu_device_name()) > 0:
             logger.info("Found a GPU.")
             logger.info(
                 "If cuDNN errors are observed, try setting the environment "


### PR DESCRIPTION
For Tensorflow 2.x you should be using tf.test.gpu_device_name() to get the number of GPUs.

Before I had this error:
"""
Traceback (most recent call last):
  File "/usr/local/software/insaflu/medaka/bin/medaka", line 8, in <module>
    sys.exit(main())
  File "/usr/local/software/insaflu/medaka/lib/python3.6/site-packages/medaka/medaka.py", line 675, in main
    args.func(args)
  File "/usr/local/software/insaflu/medaka/lib/python3.6/site-packages/medaka/prediction.py", line 129, in predict
    if len(tf.config.list_physical_devices('GPU')) > 0:
AttributeError: module 'tensorflow' has no attribute 'config'
"""