### PR TITLE
Fixes missing symbols for libdeflate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Medaka can be installed from its source quite easily on most systems.
  Before installing medaka it may be required to install some
  prerequisite libraries, best installed by a package manager. On Ubuntu
  theses are:
- >     bzip2 g++ zlib1g-dev libbz2-dev liblzma-dev libffi-dev libncurses5-dev
+ >     bzip2 g++ zlib1g-dev libbz2-dev liblzma-dev libdeflate-dev libffi-dev libncurses5-dev
  >     libcurl4-gnutls-dev libssl-dev curl make cmake wget python3-all-dev
  >     python-virtualenv
  In addition it is required to install and set up git LFS before cloning

--- a/build.py
+++ b/build.py
@@ -7,7 +7,7 @@ from cffi import FFI
 samver = "1.14"
 htslib_dir=os.path.join('submodules', 'samtools-{}'.format(samver), 'htslib-{}'.format(samver))
 
-libraries=['m', 'z', 'lzma', 'bz2', 'pthread', 'curl', 'crypto']
+libraries=['m', 'z', 'lzma', 'bz2', 'deflate', 'pthread', 'curl', 'crypto']
 library_dirs=[htslib_dir]
 src_dir='src'
 


### PR DESCRIPTION
Version 1.4.4 and 1.5 are affected.

Building `htslib.a` on a system that provide libdeflate ends up with an import error:
```
ImportError: virtual_envs/medaka_v1.4.4/lib/python3.8/site-packages/libmedaka.abi3.so: undefined symbol: libdeflate_crc32
```

A quick solution is to link against `libdeflate`.
Alternative solutions : 
- Build htslib.so and link to it
- Use system htslib when available.