### PR TITLE
bump nvidia cuda base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu18.04
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Oxford Nanopore Technologies"


### PR DESCRIPTION
So medaka requires tensorflow 2.5.2: https://github.com/nanoporetech/medaka/blob/ebe03ab23918f74b8b281bd015a77804fad8f43a/requirements.txt#L8
tensorflow 2.5.2 is build with cudnn 8.1.0: https://github.com/tensorflow/tensorflow/blob/v2.5.2/RELEASE.md (ctrl-f for cudnn)
The base image though installs cudnn 8.0.5: https://gitlab.com/nvidia/container-images/cuda/-/blob/388261dcb9d0e0d6bca8e07441c99b27c072583b/dist/11.0.3/ubuntu1804/runtime/cudnn8/Dockerfile#L6

This yields the error:
```
Loaded runtime CuDNN library: 8.0.5 but source was compiled with: 8.1.0.  CuDNN library needs to have matching major version and equal or higher minor version. If using a binary install, upgrade your CuDNN library.  If building from sources, make sure the library loaded at runtime is compatible with the version specified during compile configuration.
```

With cuda base 11.2.2, the cudnn version is [8.1.1.33](https://gitlab.com/nvidia/container-images/cuda/-/blob/388261dcb9d0e0d6bca8e07441c99b27c072583b/dist/11.2.2/ubuntu1804/runtime/cudnn8/Dockerfile#L6), which is compat.

Bumping the base image fixes this.