### PR TITLE
convey gaps in consensus sequence via a designated character, e.g. N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- capability to fill gaps in consensus sequence with a designated character 
+  (e.g. 'N') instead of content from a reference sequence.
+- option `-r` in `medaka_consensus` to set the designated fill character.
+- option `--fill_char` in `medaka stitch` to set the designated fill character.
+
 ## [v1.6.1]
 ### Added
 - New models for R10.4.1 E8.2 400bps based sequencing chemistries.

--- a/medaka/medaka.py
+++ b/medaka/medaka.py
@@ -502,6 +502,10 @@ def medaka_parser():
     sparser.add_argument('--no-fillgaps',
         help="Don't fill gaps in consensus sequence with draft sequence.",
         default=True, action='store_false', dest='fillgaps')
+    sparser.add_argument(
+        '--fill_char',
+        help="Use a designated character to fill gaps.",
+        default=None, type=str)
     sparser.add_argument('--qualities',
         help="Output with per-base quality scores (fastq).",
         action='store_true')

--- a/medaka/test/test_stitch.py
+++ b/medaka/test/test_stitch.py
@@ -109,7 +109,7 @@ class TestStitch(unittest.TestCase):
             # gaps should have sequences as Ns and qualities as !s
             for (gap_start, gap_end) in case[4]:
                 gap_len = gap_end - gap_start
-                self.assertEqual("".join(['N'] * gap_len),
+                self.assertEqual("N" * gap_len,
                                  stitched_seq[gap_start:gap_end])
                 self.assertEqual("".join(['!'] * gap_len),
                                  stitched_qual[gap_start:gap_end])

--- a/medaka/test/test_stitch.py
+++ b/medaka/test/test_stitch.py
@@ -111,7 +111,7 @@ class TestStitch(unittest.TestCase):
                 gap_len = gap_end - gap_start
                 self.assertEqual("N" * gap_len,
                                  stitched_seq[gap_start:gap_end])
-                self.assertEqual("".join(['!'] * gap_len),
+                self.assertEqual("!" * gap_len,
                                  stitched_qual[gap_start:gap_end])
         os.remove(draft)
 

--- a/scripts/medaka_consensus
+++ b/scripts/medaka_consensus
@@ -26,6 +26,7 @@ MODELS=$(
 BATCH_SIZE=100
 FORCE=false
 NOFILLGAPS=false
+GAPFILLCHAR=""
 
 iflag=false
 dflag=false
@@ -45,6 +46,7 @@ $(basename "$0") [-h] -i <fastx> -d <fasta>
     -d  fasta input assembly (required).
     -o  output folder (default: medaka).
     -g  don't fill gaps in consensus with draft sequence.
+    -r  use gap-filling character instead of draft sequence (default: None)
     -m  medaka model, (default: ${MODEL}).
         Choices: ${MODELS}
         Alternatively a .tar.gz/.hdf file from 'medaka train'.
@@ -54,13 +56,14 @@ $(basename "$0") [-h] -i <fastx> -d <fasta>
     -b  batchsize, controls memory use (default: ${BATCH_SIZE})."
 
 
-while getopts ':hi::d:o:gm:fxt:b:' option; do
+while getopts ':hi::d:o:gr:m:fxt:b:' option; do
   case "$option" in
     h  ) echo "$usage" >&2; exit;;
     i  ) iflag=true; BASECALLS=$(follow_link $OPTARG);;
     d  ) dflag=true; DRAFT=$(follow_link $OPTARG);;
     o  ) OUTPUT=$OPTARG;;
     g  ) NOFILLGAPS=true;;
+    r  ) GAPFILLCHAR=$OPTARG;;
     m  ) MODEL=$(medaka tools resolve_model --model $OPTARG);;
     f  ) FORCE=true;;
     x  ) xflag=true;;
@@ -151,6 +154,9 @@ if [[ ! -e "${CONSENSUS}" ]] || ${FORCE}; then
     STITCH_OPTS=""
     if $rflag || ${NOFILLGAPS}; then
         STITCH_OPTS="--no-fillgaps"
+    fi
+    if [ -n "${GAPFILLCHAR}" ]; then
+        STITCH_OPTS="${STITCH_OPTS} --fill_char ${GAPFILLCHAR}"
     fi
     medaka stitch "${CONSENSUSPROBS}" "${DRAFT}" "${CONSENSUS}" \
         --threads "${THREADS}" ${STITCH_OPTS} \


### PR DESCRIPTION
Addresses #348

Introduces option to convey gaps in consensus sequences via a designated character, e.g. 'N'.


### Example

Consider the following two contigs aligned to a reference

```
reference           ACACCGCGGTGTTATA
contigs             ACAC    GTGC    
```

The default behavior for `medaka_consensus` is to use information from contigs where available, and fill gaps by copying content from the reference. Alternatively, the `-g` option splits the consensus into separate pieces. 

The PR introduces capability to produce a consensus similarly as in the default mode, but fill gaps with a designated character such as 'N'.

```
reference           ACACCGCGGTGTTATA
contigs             ACAC    GTGC    
consensus (default) ACACCGCGGTGCTATA
consensus (-g)      ACAC
                            GTGC
consensus (-r N)    ACACNNNNGTGCNNNN
```

The new scheme conveys what parts of the consensus are based on data, and what parts are based on prior knowledge.

### Command line interface

The shell commands to produce the above results are:

```
medaka_consensus -i reads.fa -d reference.fa          # default behavior
medaka_consensus -i reads.fa -d reference.fa -g       # separate lines
medaka_consensus -i reads.fa -d reference.fa -r N     # fill gaps with N
```

The PR also introduces a new option `--fill_char` to `medaka stitch`.
